### PR TITLE
Renamed flags and removed nested ifs

### DIFF
--- a/openawsem/functionTerms/hydrogenBondTerms.py
+++ b/openawsem/functionTerms/hydrogenBondTerms.py
@@ -527,11 +527,11 @@ def pap_term_2(oa, k=0.5*kilocalories_per_mole, dis_i_to_i4=1.2, forceGroup=28, 
     else:
         raise ValueError(f"version must be 'efficiency_optimized' or 'lammps_awsemmd', but was {version}")  
 
-def pap_term_old(oa, k_pap=4.184, forceGroup=26, ssweight_file="ssweight", enable_parallel_bonds=True, enable_antiparallel_bonds=True):
+def pap_term_old(oa, k_pap=4.184, forceGroup=26, ssweight_file="ssweight", enable_antiparallel=True, enable_parallel=True):
     """
     Wrapper that allows us to call hydrogenBondTerms.pap_term_old() in forces_setup.py as before.
     """
-    return _pap_lammps_awsemmd(oa, ssweight_file, forceGroup, k_pap, enable_parallel_bonds, enable_parallel_bonds)
+    return _pap_lammps_awsemmd(oa, ssweight_file, forceGroup, k_pap, enable_antiparallel, enable_parallel)
 
 def helical_term(oa, k_helical=4.184, inMembrane=False, forceGroup=29):
     """
@@ -929,7 +929,7 @@ def _beta_efficiency_optimized(oa, term_number, ssweight_file, forceGroup, k_bet
             raise ValueError(f"term_number must be 1, 2, or 3, but was {term_number}")
     return Beta
 
-def _pap_lammps_awsemmd(oa, ssweight_file, forceGroup, k_pap, enable_parallel_bonds=True, enable_antiparallel_bonds=True):
+def _pap_lammps_awsemmd(oa, ssweight_file, forceGroup, k_pap, enable_antiparallel=True, enable_parallel=True):
     print("pap term ON")
     # define constants
     nres, ca = oa.nres, oa.ca
@@ -962,7 +962,7 @@ def _pap_lammps_awsemmd(oa, ssweight_file, forceGroup, k_pap, enable_parallel_bo
             # check if we may be able to add an antiparallel hydrogen bond
             delta = j-i
             intrachain = inSameChain(i,j,oa.chain_starts,oa.chain_ends)
-            if enable_antiparallel_bonds:
+            if enable_antiparallel:
                 if not inSameChain(j,j-4,oa.chain_starts,oa.chain_ends):
                     continue # Not a valid j
                 if intrachain and delta < 13: #The pair is too close to be a hairpin bond
@@ -978,7 +978,7 @@ def _pap_lammps_awsemmd(oa, ssweight_file, forceGroup, k_pap, enable_parallel_bo
                     raise AssertionError("unexpected else block")
                 pap.addBond([ca[i],ca[j],ca[i+4],ca[j-4]], [K])
             # check if we may be able to add a parallel hydrogen bond
-            if enable_parallel_bonds:
+            if enable_parallel:
                 if not inSameChain(j,j+4,oa.chain_starts,oa.chain_ends):
                     continue # Not a valid j
                 if intrachain and delta < 9:

--- a/openawsem/functionTerms/hydrogenBondTerms.py
+++ b/openawsem/functionTerms/hydrogenBondTerms.py
@@ -955,12 +955,14 @@ def _pap_lammps_awsemmd(oa, ssweight_file, forceGroup, k_pap, one_only, two_only
         pap.setUsesPeriodicBoundaryConditions(False)
     # add Bonds to Force and set per-bond parameters (coefficients)
     for i in range(nres):
-        in_same_chain_i = inSameChain(i,i+4,oa.chain_starts,oa.chain_ends)
+        if not inSameChain(i,i+4,oa.chain_starts,oa.chain_ends):
+            # Not a valid i
+            continue
         for j in range(nres):
             # check if we may be able to add an antiparallel hydrogen bond
             delta = j-i
             if not two_only:
-                if in_same_chain_i and inSameChain(j,j-4,oa.chain_starts,oa.chain_ends):
+                if inSameChain(j,j-4,oa.chain_starts,oa.chain_ends):
                     # determine whether this bond should be hairpin or long-range antiparallel
                     if not inSameChain(i,j,oa.chain_starts,oa.chain_ends):
                         # bond must be the long-range type for interchain interactions
@@ -984,7 +986,7 @@ def _pap_lammps_awsemmd(oa, ssweight_file, forceGroup, k_pap, one_only, two_only
                     pap.addBond([ca[i],ca[j],ca[i+4],ca[j-4]], [K])
             # check if we may be able to add a parallel hydrogen bond
             if not one_only:
-                if in_same_chain_i and inSameChain(j,j+4,oa.chain_starts,oa.chain_ends):
+                if inSameChain(j,j+4,oa.chain_starts,oa.chain_ends):
                     # we can assign the same K regardless of whether we're in the same chain or not
                     if rama_biases[i][1] == 1 and rama_biases[j][1] == 1:
                         K = gamma_p*k_beta_pred_p_ap

--- a/openawsem/functionTerms/hydrogenBondTerms.py
+++ b/openawsem/functionTerms/hydrogenBondTerms.py
@@ -962,40 +962,42 @@ def _pap_lammps_awsemmd(oa, ssweight_file, forceGroup, k_pap, one_only, two_only
             # check if we may be able to add an antiparallel hydrogen bond
             delta = j-i
             if not two_only:
-                if inSameChain(j,j-4,oa.chain_starts,oa.chain_ends):
-                    # determine whether this bond should be hairpin or long-range antiparallel
-                    if not inSameChain(i,j,oa.chain_starts,oa.chain_ends):
-                        # bond must be the long-range type for interchain interactions
+                if not inSameChain(j,j-4,oa.chain_starts,oa.chain_ends):
+                    continue # Not a valid j
+                # determine whether this bond should be hairpin or long-range antiparallel
+                if inSameChain(i,j,oa.chain_starts,oa.chain_ends):
+                    # bond may be either hairpin, long-range, or impossible
+                    if delta<13:
+                        continue
+                    elif 13<=delta<17:
+                        K = gamma_aph # we don't rescale potential by k_beta_pred_p_ap for hairpin
+                    elif 17<=delta:
                         if rama_biases[i][1] == 1 and rama_biases[j][1] == 1:
                             K = gamma_ap*k_beta_pred_p_ap
                         else:
                             K = gamma_ap
                     else:
-                        # bond may be either hairpin, long-range, or impossible
-                        if delta<13:
-                            continue
-                        elif 13<=delta<17:
-                            K = gamma_aph # we don't rescale potential by k_beta_pred_p_ap for hairpin
-                        elif 17<=delta:
-                            if rama_biases[i][1] == 1 and rama_biases[j][1] == 1:
-                                K = gamma_ap*k_beta_pred_p_ap
-                            else:
-                                K = gamma_ap
-                        else:
-                            raise AssertionError("unexpected else block")
-                    pap.addBond([ca[i],ca[j],ca[i+4],ca[j-4]], [K])
+                        raise AssertionError("unexpected else block")
+                else:
+                    # bond must be the long-range type for interchain interactions
+                    if rama_biases[i][1] == 1 and rama_biases[j][1] == 1:
+                        K = gamma_ap*k_beta_pred_p_ap
+                    else:
+                        K = gamma_ap
+                pap.addBond([ca[i],ca[j],ca[i+4],ca[j-4]], [K])
             # check if we may be able to add a parallel hydrogen bond
             if not one_only:
-                if inSameChain(j,j+4,oa.chain_starts,oa.chain_ends):
-                    # we can assign the same K regardless of whether we're in the same chain or not
-                    if rama_biases[i][1] == 1 and rama_biases[j][1] == 1:
-                        K = gamma_p*k_beta_pred_p_ap
-                    else:
-                        K = gamma_p
-                    if inSameChain(i,j,oa.chain_starts,oa.chain_ends) and delta < 9:
-                        # we don't add a bond if the sequence separation is less than 9
-                        continue
-                    pap.addBond([ca[i],ca[j],ca[i+4],ca[j+4]], [K])
+                if not inSameChain(j,j+4,oa.chain_starts,oa.chain_ends):
+                    continue # Not a valid j
+                if inSameChain(i,j,oa.chain_starts,oa.chain_ends) and delta < 9:
+                    # The pair is too close to be a parallel bond
+                    continue
+                # we can assign the same K regardless of whether we're in the same chain or not
+                if rama_biases[i][1] == 1 and rama_biases[j][1] == 1:
+                    K = gamma_p*k_beta_pred_p_ap
+                else:
+                    K = gamma_p
+                pap.addBond([ca[i],ca[j],ca[i+4],ca[j+4]], [K])
             
     pap.setForceGroup(forceGroup)
     return pap

--- a/openawsem/functionTerms/hydrogenBondTerms.py
+++ b/openawsem/functionTerms/hydrogenBondTerms.py
@@ -968,22 +968,20 @@ def _pap_lammps_awsemmd(oa, ssweight_file, forceGroup, k_pap, one_only, two_only
                             K = gamma_ap*k_beta_pred_p_ap
                         else:
                             K = gamma_ap
-                        pap.addBond([ca[i],ca[j],ca[i+4],ca[j-4]], [K])
                     else:
                         # bond may be either hairpin, long-range, or impossible
                         if delta<13:
-                            pass
+                            continue
                         elif 13<=delta<17:
                             K = gamma_aph # we don't rescale potential by k_beta_pred_p_ap for hairpin
-                            pap.addBond([ca[i],ca[j],ca[i+4],ca[j-4]], [K])
                         elif 17<=delta:
                             if rama_biases[i][1] == 1 and rama_biases[j][1] == 1:
                                 K = gamma_ap*k_beta_pred_p_ap
                             else:
                                 K = gamma_ap
-                            pap.addBond([ca[i],ca[j],ca[i+4],ca[j-4]], [K])
                         else:
                             raise AssertionError("unexpected else block")
+                    pap.addBond([ca[i],ca[j],ca[i+4],ca[j-4]], [K])
             # check if we may be able to add a parallel hydrogen bond
             if not one_only:
                 if in_same_chain_i and inSameChain(j,j+4,oa.chain_starts,oa.chain_ends):
@@ -992,14 +990,10 @@ def _pap_lammps_awsemmd(oa, ssweight_file, forceGroup, k_pap, one_only, two_only
                         K = gamma_p*k_beta_pred_p_ap
                     else:
                         K = gamma_p
-                    if not inSameChain(i,j,oa.chain_starts,oa.chain_ends):
-                        # we can add the bond regardless of sequence separation
-                        pap.addBond([ca[i],ca[j],ca[i+4],ca[j+4]], [K])
-                    else:
-                        if delta < 9:
-                            pass
-                        else:
-                            pap.addBond([ca[i],ca[j],ca[i+4],ca[j+4]], [K])
+                    if inSameChain(i,j,oa.chain_starts,oa.chain_ends) and delta < 9:
+                        # we don't add a bond if the sequence separation is less than 9
+                        continue
+                    pap.addBond([ca[i],ca[j],ca[i+4],ca[j+4]], [K])
             
     pap.setForceGroup(forceGroup)
     return pap

--- a/openawsem/functionTerms/hydrogenBondTerms.py
+++ b/openawsem/functionTerms/hydrogenBondTerms.py
@@ -955,11 +955,12 @@ def _pap_lammps_awsemmd(oa, ssweight_file, forceGroup, k_pap, one_only, two_only
         pap.setUsesPeriodicBoundaryConditions(False)
     # add Bonds to Force and set per-bond parameters (coefficients)
     for i in range(nres):
+        in_same_chain_i = inSameChain(i,i+4,oa.chain_starts,oa.chain_ends)
         for j in range(nres):
             # check if we may be able to add an antiparallel hydrogen bond
             delta = j-i
             if not two_only:
-                if inSameChain(i,i+4,oa.chain_starts,oa.chain_ends) and inSameChain(j,j-4,oa.chain_starts,oa.chain_ends):
+                if in_same_chain_i and inSameChain(j,j-4,oa.chain_starts,oa.chain_ends):
                     # determine whether this bond should be hairpin or long-range antiparallel
                     if not inSameChain(i,j,oa.chain_starts,oa.chain_ends):
                         # bond must be the long-range type for interchain interactions
@@ -985,7 +986,7 @@ def _pap_lammps_awsemmd(oa, ssweight_file, forceGroup, k_pap, one_only, two_only
                             raise AssertionError("unexpected else block")
             # check if we may be able to add a parallel hydrogen bond
             if not one_only:
-                if inSameChain(i,i+4,oa.chain_starts,oa.chain_ends) and inSameChain(j,j+4,oa.chain_starts,oa.chain_ends):
+                if in_same_chain_i and inSameChain(j,j+4,oa.chain_starts,oa.chain_ends):
                     # we can assign the same K regardless of whether we're in the same chain or not
                     if rama_biases[i][1] == 1 and rama_biases[j][1] == 1:
                         K = gamma_p*k_beta_pred_p_ap


### PR DESCRIPTION
I renamed the one_only/two_only flags to enable_parallel_bonds/enable_antiparallel_bonds to make it more descriptive. Also moved some of the logic outside the nested for loops and reduced the nesting of the if statements to make the logic clearer.